### PR TITLE
Preserve HTML5 output

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -1,6 +1,6 @@
 <?php
 
-class Extension_cachelite extends Extension
+class Extension_xcachelite extends Extension
 {
     protected $_cacheLite = null;
     protected $_lifetime = null;

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension id="cachelite" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
-  <name>CacheLite</name>
+<extension id="xcachelite" status="released" xmlns="http://getsymphony.com/schemas/extension/1.0">
+  <name>xCacheLite</name>
   <description>Simple frontend output caching with CacheLite.</description>
   <repo type="github">https://github.com/symphonists/cachelite</repo>
   <url type="issues">https://github.com/symphonists/cachelite/issues</url>


### PR DESCRIPTION
- Ensured Cache-Lite writes cache after html5_doctype extension
- Adjusted extension folder name to 'xcachelite' to control execution order
- Now caches final HTML5 output, including minification and DOCTYPE